### PR TITLE
buzzlex.c: Make sure there's an endline at the end of a buzz script

### DIFF
--- a/src/buzz/buzzlex.c
+++ b/src/buzz/buzzlex.c
@@ -76,6 +76,10 @@ buzzlex_file_t buzzlex_file_new(const char* fname) {
    }
    x->buf[x->buf_size] = '\n';
    x->buf[x->buf_size+1] = '\0';
+
+   /* Add the extra '\n' to the buffer to make sure it ends with a newline */
+   x->buf_size += 1;
+
    /* Done reading, close file */
    fclose(fd);
    /* Store the file name */


### PR DESCRIPTION
If a file does not end in a newline, buzzlex doesn't output anything since it quits before processing the last character (potentially a }). You did add a '\n' at the end of the buffer @ buf+buf_size but all the checks for EOF quit at buf_size-1, so the '\n' is lost. This is a rather simple fix to actually have the '\n' recognized as at the end of the buffer. In the worst case, you have an extra '\n'.