### PR TITLE
Made self-tables be pushed on the stack for future use.

### DIFF
--- a/src/buzz/buzzdebug.c
+++ b/src/buzz/buzzdebug.c
@@ -276,6 +276,8 @@ buzzvm_state buzzdebug_closure_call(buzzvm_t vm,
          vm->state = BUZZVM_STATE_READY;
       else return vm->state;
    }
+   /* Insert the self table */
+   buzzdarray_insert(vm->stack, buzzdarray_size(vm->stack) - argc - 1, buzzobj_new(BUZZTYPE_NIL));
    /* Push the argument count */
    buzzvm_pushi(vm, argc);
    /* Save the current stack depth */

--- a/src/buzz/buzzvm.c
+++ b/src/buzz/buzzvm.c
@@ -846,6 +846,10 @@ buzzvm_state buzzvm_execute_script(buzzvm_t vm) {
 
 buzzvm_state buzzvm_closure_call(buzzvm_t vm,
                                  uint32_t argc) {
+   /* Insert the self table right before the closure */
+   buzzdarray_insert(vm->stack,
+                     buzzdarray_size(vm->stack) - argc - 1,
+                     buzzobj_new(BUZZTYPE_NIL));
    /* Push the argument count */
    buzzvm_pushi(vm, argc);
    /* Save the current stack depth */
@@ -942,6 +946,8 @@ buzzvm_state buzzvm_call(buzzvm_t vm, int isswrm) {
    /* Get rid of the function arguments */
    for(i = argn+1; i > 0; --i)
       buzzdarray_pop(vm->stack);
+   /* Pop unused self table */
+   buzzdarray_pop(vm->stack);
    /* Push return address */
    buzzvm_pushi((vm), vm->pc);
    /* Make a new stack for the function */

--- a/src/testing/testparsing.bzz
+++ b/src/testing/testparsing.bzz
@@ -43,3 +43,58 @@ else {
 # }
 
 # f()
+
+function foo() {
+  print("foo(); ", self)
+  return { # Table with 2 elements
+    .x = { # Table with 3 elements
+      .y = { # Table with 4 elements
+        .c = function(s) {
+          print(".x.y['c'](); ", self)
+          return function(s) {
+            print("<anonymous>(); ", self)
+          }
+        },
+        .d = 1,
+        .e = 2,
+        .f = 3
+      },
+      .a = 1,
+      .b = 2
+    },
+    .z = 0
+  }
+}
+
+function getKey() {
+  return "c"
+}
+
+t = { .bar = foo } # Table with 1 element
+
+foo() # Prints "foo(); [nil]"
+
+# Case with no nested table
+t2 = t.bar() # Prints "foo(); [table with 1 elems]"
+
+# Case with 3 nested tables and using 2 ways of accessing fields
+t3 = t2.x.y["c"]() # Prints ".x.y['c'](); [table with 4 elems]"
+
+# Case with no nested table and called from global scope
+t3() # Prints "<anonymous>(); [table with 4 elems]" <-- Should be "[nil]", this is a bug of Buzz
+
+# Case with all in 1 line
+t.bar().x.y["c"]()()
+
+# Case with a closure call to get the table's key
+t2["x"].y[getKey()]() # Prints ".x.y['c'](); [table with 4 elems]"
+
+# --- Output:
+#   foo(); [nil]
+#   foo(); [table with 1 elems]
+#   .x.y['c'](); [table with 4 elems]
+#   <anonymous>(); [table with 4 elems]
+#   foo(); [table with 1 elems]
+#   .x.y['c'](); [table with 4 elems]
+#   <anonymous>(); [table with 4 elems]
+#   .x.y['c'](); [table with 4 elems]


### PR DESCRIPTION
This allows for optimizations on BittyBuzz. It could also be applied to Buzz, if it is needed.