### PR TITLE
added floor function to math closures

### DIFF
--- a/src/buzz/buzzmath.c
+++ b/src/buzz/buzzmath.c
@@ -160,6 +160,7 @@ int buzzmath_floor(buzzvm_t vm) {
    buzzvm_lload(vm, 1);
    buzzobj_t o = buzzvm_stack_at(vm, 1);
    if(o->o.type == BUZZTYPE_FLOAT)    buzzvm_pushi(vm, floor(o->f.value));
+   else if(o->o.type == BUZZTYPE_INT)    buzzvm_pushi(vm, o->i.value);
    else buzzmath_error(o);
    /* Return result */
    return buzzvm_ret1(vm);

--- a/src/buzz/buzzmath.c
+++ b/src/buzz/buzzmath.c
@@ -159,7 +159,7 @@ int buzzmath_floor(buzzvm_t vm) {
    /* Get argument */
    buzzvm_lload(vm, 1);
    buzzobj_t o = buzzvm_stack_at(vm, 1);
-   if(o->o.type == BUZZTYPE_FLOAT)    buzzvm_pushf(vm, floor(o->f.value));
+   if(o->o.type == BUZZTYPE_FLOAT)    buzzvm_pushi(vm, floor(o->f.value));
    else buzzmath_error(o);
    /* Return result */
    return buzzvm_ret1(vm);

--- a/src/buzz/buzzmath.c
+++ b/src/buzz/buzzmath.c
@@ -154,6 +154,20 @@ int buzzmath_abs(buzzvm_t vm) {
 /****************************************/
 /****************************************/
 
+int buzzmath_floor(buzzvm_t vm) {
+   buzzvm_lnum_assert(vm, 1);
+   /* Get argument */
+   buzzvm_lload(vm, 1);
+   buzzobj_t o = buzzvm_stack_at(vm, 1);
+   if(o->o.type == BUZZTYPE_FLOAT)    buzzvm_pushf(vm, floor(o->f.value));
+   else buzzmath_error(o);
+   /* Return result */
+   return buzzvm_ret1(vm);
+}
+
+/****************************************/
+/****************************************/
+
 int buzzmath_log(buzzvm_t vm) {
    buzzvm_lnum_assert(vm, 1);
    /* Get argument */

--- a/src/buzz/buzzmath.h
+++ b/src/buzz/buzzmath.h
@@ -11,6 +11,8 @@ extern "C" {
 
    extern int buzzmath_abs(buzzvm_t vm);
 
+   extern int buzzmath_floor(buzzvm_t vm);
+
    extern int buzzmath_log(buzzvm_t vm);
 
    extern int buzzmath_log2(buzzvm_t vm);


### PR DESCRIPTION
int floor(float) is required to deal with grids, such as in the RRT* algorithm.