### PR TITLE
strsep can return null #2

### DIFF
--- a/src/buzz/buzzasm.c
+++ b/src/buzz/buzzasm.c
@@ -220,9 +220,15 @@ int buzz_asm(const char* fname,
             char* line = strsep(&debuginfo, ",\n");
             char* col = strsep(&debuginfo, ",\n");
             char* srcfname = strsep(&debuginfo, ",\n");
-            uint64_t l = strtol(line, NULL, 10);
-            uint64_t c = strtol(col, NULL, 10);
-            buzzdebug_info_set(*dbg, *size, l, c,srcfname);
+            uint64_t l = 0;
+            uint64_t c = 0;
+            if (line) {
+              l = strtol(line, NULL, 10);
+            }
+            if (col) {
+              c = strtol(col, NULL, 10);
+            }
+            buzzdebug_info_set(*dbg, *size, l, c, srcfname);
          }
          /* Remove trailing space from label info */
          endc = labelinfo + strlen(labelinfo) - 1;


### PR DESCRIPTION
I did not look far enough into the code.  I have a second input that causes this area of the code to seg fault.

The file is non-text so it is here in base64 encoding: `QI+Pj4+Pj4+Pj4+Pj48Qj4+Pj4+Pj498QA==`.

This is directly related to #48 