### PR TITLE
bcode_resize adjustment

### DIFF
--- a/src/buzz/buzzasm.c
+++ b/src/buzz/buzzasm.c
@@ -15,7 +15,7 @@
  */
 #define bcode_resize(INC)                       \
    if((*size) + (INC) >= bcode_max_size) {      \
-      bcode_max_size *= 2;                      \
+      bcode_max_size += INC;                    \
       *buf = realloc(*buf, bcode_max_size);     \
    }                                            \
 


### PR DESCRIPTION
`bcode_resize(INC)` was guessing a bit at what size to resize the buffer to.  I'm not certain it is correct, but it seems to be better and resolves a crash condition found via fuzzing.