### PR TITLE
buzzlex_file_new PATH_MAX limit

### DIFF
--- a/src/buzz/buzzlex.c
+++ b/src/buzz/buzzlex.c
@@ -22,6 +22,9 @@ char *buzztok_desc[] = {
 buzzlex_file_t buzzlex_file_new(const char* fname) {
    /* Find the file, possibly using the include path */
    char fpath[PATH_MAX];
+   if (strlen(fname) > (PATH_MAX - 1)) {
+     return NULL;
+   }
    strcpy(fpath, fname);
    FILE* fd = fopen(fpath, "rb");
    if(!fd) {


### PR DESCRIPTION
I'm not certain returning NULL is the proper solution, but it keeps segmentation fault from occurring via the strcpy.  As always, feedback welcome.