### PR TITLE
Allow CBuzzFootBotController subclassing

### DIFF
--- a/src/buzz/argos/buzz_controller_footbot.h
+++ b/src/buzz/argos/buzz_controller_footbot.h
@@ -62,7 +62,7 @@ public:
    void TurretDisable();
    void TurretSet(Real f_rotation);
 
-private:
+protected:
 
    virtual buzzvm_state RegisterFunctions();
 


### PR DESCRIPTION
Minor change to allow the creation of controllers based on the footbot with custom functions. 
When `RegisterFunctions()` is private, it is not possible to call it from a subclass to add new functions while still registering the superclass (`CBuzzFootBotController`) functions.
Note that `RegisterFunctions()` is already `protected` in the [spiri controller](https://github.com/MISTLab/Buzz/blob/fb77f4ec76ad1bbb22220ea0afbf970f6cb774fe/src/buzz/argos/buzz_controller_spiri.h#L27).