### PR TITLE
Add option to show (or not) the live buzz editor

### DIFF
--- a/src/buzz/argos/buzz_qt.cpp
+++ b/src/buzz/argos/buzz_qt.cpp
@@ -19,7 +19,14 @@ CBuzzQT::~CBuzzQT() {
 
 void CBuzzQT::Init(TConfigurationNode& t_tree) {
    m_pcEditor = new CBuzzQTMainWindow(&GetMainWindow());
-   m_pcEditor->show();
+   bool showEditor = true;
+   if (NodeAttributeExists(t_tree, "show_buzz_editor"))
+   {
+      GetNodeAttribute(t_tree, "show_buzz_editor", showEditor);
+   }
+   if (showEditor) {
+      m_pcEditor->show();
+   }
 }
 
 /****************************************/


### PR DESCRIPTION
This modification adds an option to define `show_buzz_editor` in the .argos configuration file to show/hide the editor. 
This solves an issue I encountered when using an X server on Windows to run an ARGoS simulation. The X server could only show one application window at a time and it was the Buzz Editor. By setting  `show_buzz_editor` to `false`, the editor is hidden and the simulation is shown properly.
The new `show_buzz_editor` option is not mandatory so I believe this fix should not affect the compatibility with previous .argos config files.
The default behavior is also unchanged.