### PR TITLE
Better compilation scripts

### DIFF
--- a/src/buzz/argos/CMakeLists.txt
+++ b/src/buzz/argos/CMakeLists.txt
@@ -27,6 +27,7 @@ if(ARGOS_QTOPENGL_FOUND)
 endif(ARGOS_QTOPENGL_FOUND)
 
 add_library(argos3plugin_simulator_buzz SHARED ${ARGOS_BUZZ_SOURCES})
+add_dependencies(argos3plugin_simulator_buzz buzz)
 target_link_libraries(argos3plugin_simulator_buzz
   argos3core_simulator
   argos3plugin_simulator_genericrobot

--- a/src/testing/CMakeLists.txt
+++ b/src/testing/CMakeLists.txt
@@ -29,6 +29,21 @@ endif(ARGOS_FOUND)
 # Test scripts
 #
 
+function(_buzz_make_test _script)
+  if(ARGN)
+    if(NOT ARGV1 STREQUAL "INCLUDES")
+      message(FATAL_ERROR "Expected INCLUDES in _buzz_make_test(script INCLUDES ...), got ${ARGV1}")
+    endif(NOT ARGV1 STREQUAL "INCLUDES")
+    if(ARGC LESS 3)
+      message(FATAL_ERROR "Expected scripts to include in _buzz_make_test(script INCLUDES ...)")
+    endif(ARGC LESS 3)
+    buzz_make(${_script} ${ARGN})
+  else(ARGN)
+    buzz_make(${_script})
+  endif(ARGN)
+  add_dependencies(${_script} bzzasm bzzdeasm bzzparse)
+endfunction(_buzz_make_test)
+
 if(NOT CMAKE_CROSSCOMPILING)
   # Make sure only the locally compiled tools are used
   set(BUZZ_COMPILER ${CMAKE_BINARY_DIR}/utility/bzzc)
@@ -41,93 +56,34 @@ if(NOT CMAKE_CROSSCOMPILING)
   set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/utility)
   include(UseBuzz)
 
-  buzz_make(test_takeoff_divide_flock.bzz)
-  add_dependencies(test_takeoff_divide_flock.bzz bzzparse)
-  
-  buzz_make(testempty.bzz)
-  add_dependencies(testempty.bzz bzzparse)
-  
-  buzz_make(testif.bzz)
-  add_dependencies(testif.bzz bzzparse)
-  
-  buzz_make(testdebug.bzz)
-  add_dependencies(testdebug.bzz bzzparse)
-  
-  buzz_make(testdocstring.bzz)
-  add_dependencies(testdocstring.bzz bzzparse)
-  
-  buzz_make(testbehavior.bzz)
-  add_dependencies(testbehavior.bzz bzzparse)
-  
-  buzz_make(testclosure.bzz)
-  add_dependencies(testclosure.bzz bzzparse)
-  
-  buzz_make(testhexagon.bzz)
-  add_dependencies(testhexagon.bzz bzzparse)
-  
-  buzz_make(testsquare.bzz)
-  add_dependencies(testsquare.bzz bzzparse)
-  
-  buzz_make(testgradient.bzz)
-  add_dependencies(testgradient.bzz bzzparse)
-  
-  buzz_make(testinclude1.bzz INCLUDES testinclude2.bzz)
-  add_dependencies(testinclude1.bzz bzzparse)
-  
-  buzz_make(testio.bzz)
-  add_dependencies(testio.bzz bzzparse)
-  
-  buzz_make(testleds.bzz)
-  add_dependencies(testleds.bzz bzzparse)
-  
-  buzz_make(testmath.bzz)
-  add_dependencies(testmath.bzz bzzparse)
-  
-  buzz_make(testexpressions.bzz)
-  add_dependencies(testexpressions.bzz bzzparse)
-  
-  buzz_make(testmsg.bzz)
-  add_dependencies(testmsg.bzz bzzparse)
-  
-  buzz_make(testneighbors.bzz)
-  add_dependencies(testneighbors.bzz bzzparse)
-  
-  buzz_make(testparsing.bzz)
-  add_dependencies(testparsing.bzz bzzparse)
-  
-  buzz_make(teststigmergy.bzz)
-  add_dependencies(teststigmergy.bzz bzzparse)
-  
-  buzz_make(teststring.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/string.bzz)
-  add_dependencies(teststring.bzz bzzparse)
-  
-  buzz_make(testswarm.bzz)
-  add_dependencies(testswarm.bzz bzzparse)
-  
-  buzz_make(testtable.bzz)
-  add_dependencies(testtable.bzz bzzparse)
-  
-  buzz_make(testvec2.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/vec2.bzz)
-  add_dependencies(testvec2.bzz bzzparse)
-  
-  buzz_make(testwhile.bzz)
-  add_dependencies(testwhile.bzz bzzparse)
-  
-  buzz_make(testfor.bzz)
-  add_dependencies(testfor.bzz bzzparse)
-  
-  buzz_make(testmobilecode.bzz)
-  add_dependencies(testmobilecode.bzz bzzparse)
-  
-  buzz_make(testbattery.bzz)
-  add_dependencies(testbattery.bzz bzzparse)
-  
-  buzz_make(testtablelib.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/table.bzz)
-  add_dependencies(testtablelib.bzz bzzparse)
-  
-  buzz_make(testneighborsmapreduce.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/neighbors.bzz ${CMAKE_SOURCE_DIR}/include/table.bzz)
-  add_dependencies(testneighborsmapreduce.bzz bzzparse)
-  
-  buzz_make(testtype.bzz)
-  add_dependencies(testtype.bzz bzzparse)  
+  _buzz_make_test(test_takeoff_divide_flock.bzz)
+  _buzz_make_test(testempty.bzz)
+  _buzz_make_test(testif.bzz)
+  _buzz_make_test(testdebug.bzz)
+  _buzz_make_test(testdocstring.bzz)
+  _buzz_make_test(testbehavior.bzz)
+  _buzz_make_test(testclosure.bzz)
+  _buzz_make_test(testhexagon.bzz)
+  _buzz_make_test(testsquare.bzz)
+  _buzz_make_test(testgradient.bzz)
+  _buzz_make_test(testinclude1.bzz INCLUDES testinclude2.bzz)
+  _buzz_make_test(testio.bzz)
+  _buzz_make_test(testleds.bzz)
+  _buzz_make_test(testmath.bzz)
+  _buzz_make_test(testexpressions.bzz)
+  _buzz_make_test(testmsg.bzz)
+  _buzz_make_test(testneighbors.bzz)
+  _buzz_make_test(testparsing.bzz)
+  _buzz_make_test(teststigmergy.bzz)
+  _buzz_make_test(teststring.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/string.bzz)
+  _buzz_make_test(testswarm.bzz)
+  _buzz_make_test(testtable.bzz)
+  _buzz_make_test(testvec2.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/vec2.bzz)
+  _buzz_make_test(testwhile.bzz)
+  _buzz_make_test(testfor.bzz)
+  _buzz_make_test(testmobilecode.bzz)
+  _buzz_make_test(testbattery.bzz)
+  _buzz_make_test(testtablelib.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/table.bzz)
+  _buzz_make_test(testneighborsmapreduce.bzz INCLUDES ${CMAKE_SOURCE_DIR}/include/neighbors.bzz ${CMAKE_SOURCE_DIR}/include/table.bzz)
+  _buzz_make_test(testtype.bzz)
 endif(NOT CMAKE_CROSSCOMPILING)

--- a/src/utility/BuzzConfig.cmake
+++ b/src/utility/BuzzConfig.cmake
@@ -1,5 +1,5 @@
 # .rst:
-# FindBuzz
+# BuzzConfig
 # --------
 #
 # Find Module for Buzz
@@ -130,10 +130,26 @@ find_path(BUZZ_BZZ_INCLUDE_DIR
   PATHS ${_BUZZ_BZZ_INCLUDE_PATHS}
   DOC "Location of the Buzz BZZ include files")
 
-# Handle the QUIETLY and REQUIRED arguments and set BUZZ_FOUND to TRUE
-# if all listed variables are TRUE
-include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(BUZZ
-  REQUIRED_VARS BUZZ_COMPILER BUZZ_PARSER BUZZ_ASSEMBLER BUZZ_LIBRARY BUZZ_LIBRARY_DEBUG BUZZ_C_INCLUDE_DIR BUZZ_BZZ_INCLUDE_DIR)
+# # Handle the QUIETLY and REQUIRED arguments and set BUZZ_FOUND to TRUE
+# # if all listed variables are TRUE
+# include(FindPackageHandleStandardArgs)
+# find_package_handle_standard_args(BUZZ
+#   REQUIRED_VARS BUZZ_COMPILER BUZZ_PARSER BUZZ_ASSEMBLER BUZZ_LIBRARY BUZZ_LIBRARY_DEBUG BUZZ_C_INCLUDE_DIR BUZZ_BZZ_INCLUDE_DIR)
+
+set(BUZZ_FOUND 0)
+if(BUZZ_COMPILER AND BUZZ_PARSER AND BUZZ_ASSEMBLER AND BUZZ_LIBRARY AND BUZZ_LIBRARY_DEBUG AND BUZZ_C_INCLUDE_DIR AND BUZZ_BZZ_INCLUDE_DIR)
+  set(BUZZ_FOUND 1)
+endif(BUZZ_COMPILER AND BUZZ_PARSER AND BUZZ_ASSEMBLER AND BUZZ_LIBRARY AND BUZZ_LIBRARY_DEBUG AND BUZZ_C_INCLUDE_DIR AND BUZZ_BZZ_INCLUDE_DIR)
+if(NOT QUIET)
+  if(BUZZ_FOUND)
+    message(STATUS "Buzz compiler found: ${BUZZ_COMPILER}")
+    message(STATUS "Buzz library found: ${BUZZ_LIBRARY}")
+    message(STATUS "Buzz C headers include path found: ${BUZZ_C_INCLUDE_DIR}")
+    message(STATUS "Buzz Buzz headers include path found: ${BUZZ_BZZ_INCLUDE_DIR}")
+  else(BUZZ_FOUND)
+    message(STATUS "Buzz not found")
+  endif(BUZZ_FOUND)
+endif(NOT QUIET)
+set(BUZZ_FOUND ${BUZZ_FOUND} CACHE BOOL "Whether Buzz was found")
 
 mark_as_advanced(BUZZ_COMPILER BUZZ_PARSER BUZZ_ASSEMBLER BUZZ_LIBRARY BUZZ_LIBRARY_DEBUG BUZZ_C_INCLUDE_DIR BUZZ_BZZ_INCLUDE_DIR)

--- a/src/utility/CMakeLists.txt
+++ b/src/utility/CMakeLists.txt
@@ -40,19 +40,7 @@ install(FILES buzz-mode.el DESTINATION share/buzz/emacs)
 #
 # Install CMake modules and scripts
 #
-install(FILES FindBuzz.cmake UseBuzz.cmake DESTINATION share/buzz/cmake)
-if(BUZZ_SYMLINK_CMAKE_SCRIPTS)
-  install(CODE "execute_process(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-    ${CMAKE_INSTALL_PREFIX}/share/buzz/cmake/FindBuzz.cmake
-    ${CMAKE_ROOT}/Modules/FindBuzz.cmake
-    )")
-  install(CODE "execute_process(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-    ${CMAKE_INSTALL_PREFIX}/share/buzz/cmake/UseBuzz.cmake
-    ${CMAKE_ROOT}/Modules/UseBuzz.cmake
-    )")
-endif(BUZZ_SYMLINK_CMAKE_SCRIPTS)
+install(FILES BuzzConfig.cmake UseBuzz.cmake DESTINATION share/buzz/cmake)
 
 #
 # Compress and install man pages in share/man/man1

--- a/src/utility/UseBuzz.cmake
+++ b/src/utility/UseBuzz.cmake
@@ -96,12 +96,15 @@ function(buzz_make _SCRIPT)
     set(_buzz_make_BUZZ_INCLUDE_PATH "-I" "${_buzz_make_BUZZ_INCLUDE_PATH}")
   endif(NOT _buzz_make_BUZZ_INCLUDE_PATH STREQUAL "")
   # Define compilation command
+  if(_buzz_make_INCLUDES)
+    set(_buzz_make_INCLUDES_msg ", including \"${_buzz_make_INCLUDES}\"")
+  endif(_buzz_make_INCLUDES)
   add_custom_command(
     OUTPUT "${_buzz_make_BYTECODE}" "${_buzz_make_BASM}" "${_buzz_make_DEBUG}"
     COMMAND "BZZPARSE=${BUZZ_PARSER}" "BZZASM=${BUZZ_ASSEMBLER}" "${BUZZ_COMPILER}" ${_buzz_make_BUZZ_INCLUDE_PATH} -b "${_buzz_make_BYTECODE}" -d "${_buzz_make_DEBUG}" -a "${_buzz_make_BASM}" "${CMAKE_CURRENT_SOURCE_DIR}/${_SCRIPT}"
     MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/${_SCRIPT}"
     DEPENDS ${_buzz_make_INCLUDES}
-    COMMENT "Compiling Buzz script ${_SCRIPT}, including '${_buzz_make_INCLUDES}'")
+    COMMENT "Compiling Buzz script ${_SCRIPT}${_buzz_make_INCLUDES_msg}")
   # Add target, so compilation is executed
   add_custom_target("${_SCRIPT}" ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${_SCRIPT}" "${_buzz_make_BYTECODE}" "${_buzz_make_DEBUG}" ${_buzz_make_INCLUDES})
 endfunction(buzz_make)


### PR DESCRIPTION
* Parallel compilation should work as intended.
* `FindBuzz.cmake` renamed to `BuzzConfig.cmake` to make it findable by `find_package()` without the need for symlinks.
* Better message for `buzz_make()` when no includes are specified